### PR TITLE
rename GRAFANA_URL to INTERNAL_GRAFANA_URL

### DIFF
--- a/frontend/apps/auth-proxy/lib/handlers/instanceCreated.ts
+++ b/frontend/apps/auth-proxy/lib/handlers/instanceCreated.ts
@@ -21,7 +21,7 @@ export const instanceCreatedHandler = async (data: yup.InferType<typeof CreateGr
     const api = new OpenAPIClientAxios({
       definition: grafanaApi as unknown as Document,
       axiosConfigDefaults: {
-        baseURL: process.env.GRAFANA_URL,
+        baseURL: process.env.INTERNAL_GRAFANA_URL,
         auth: {
           username: process.env.GRAFANA_SA_USERNAME ?? "",
           password: process.env.GRAFANA_SA_PASSWORD ?? "",

--- a/frontend/apps/auth-proxy/lib/handlers/instanceDeleted.ts
+++ b/frontend/apps/auth-proxy/lib/handlers/instanceDeleted.ts
@@ -21,7 +21,7 @@ export const instanceDeletedHandler = async (data: yup.InferType<typeof DeleteGr
     const api = new OpenAPIClientAxios({
       definition: grafanaApi as unknown as Document,
       axiosConfigDefaults: {
-        baseURL: process.env.GRAFANA_URL,
+        baseURL: process.env.INTERNAL_GRAFANA_URL,
         auth: {
           username: process.env.GRAFANA_SA_USERNAME ?? "",
           password: process.env.GRAFANA_SA_PASSWORD ?? "",

--- a/frontend/apps/auth-proxy/lib/handlers/subscriptionCreated.ts
+++ b/frontend/apps/auth-proxy/lib/handlers/subscriptionCreated.ts
@@ -23,7 +23,7 @@ export const subscriptionCreatedHandler = async (data: yup.InferType<typeof Crea
     const api = new OpenAPIClientAxios({
       definition: grafanaApi as unknown as Document,
       axiosConfigDefaults: {
-        baseURL: process.env.GRAFANA_URL,
+        baseURL: process.env.INTERNAL_GRAFANA_URL,
         auth: {
           username: process.env.GRAFANA_SA_USERNAME ?? "",
           password: process.env.GRAFANA_SA_PASSWORD ?? "",

--- a/frontend/apps/auth-proxy/lib/handlers/subscriptionDeleted.ts
+++ b/frontend/apps/auth-proxy/lib/handlers/subscriptionDeleted.ts
@@ -18,7 +18,7 @@ export const subscriptionDeletedHandler = async (data: yup.InferType<typeof Dele
     const api = new OpenAPIClientAxios({
       definition: grafanaApi as unknown as Document,
       axiosConfigDefaults: {
-        baseURL: process.env.GRAFANA_URL,
+        baseURL: process.env.INTERNAL_GRAFANA_URL,
         auth: {
           username: process.env.GRAFANA_SA_USERNAME ?? "",
           password: process.env.GRAFANA_SA_PASSWORD ?? "",

--- a/frontend/apps/auth-proxy/lib/handlers/userCreated.ts
+++ b/frontend/apps/auth-proxy/lib/handlers/userCreated.ts
@@ -24,7 +24,7 @@ export const userCreatedHandler = async (data: yup.InferType<typeof AddUserAcces
     const api = new OpenAPIClientAxios({
       definition: grafanaApi as unknown as Document,
       axiosConfigDefaults: {
-        baseURL: process.env.GRAFANA_URL,
+        baseURL: process.env.INTERNAL_GRAFANA_URL,
         auth: {
           username: process.env.GRAFANA_SA_USERNAME ?? "",
           password: process.env.GRAFANA_SA_PASSWORD ?? "",

--- a/frontend/apps/auth-proxy/lib/handlers/userDeleted.ts
+++ b/frontend/apps/auth-proxy/lib/handlers/userDeleted.ts
@@ -21,7 +21,7 @@ export const userDeletedHandler = async (data: yup.InferType<typeof RemoveUserAc
     const api = new OpenAPIClientAxios({
       definition: grafanaApi as unknown as Document,
       axiosConfigDefaults: {
-        baseURL: process.env.GRAFANA_URL,
+        baseURL: process.env.INTERNAL_GRAFANA_URL,
         auth: {
           username: process.env.GRAFANA_SA_USERNAME ?? "",
           password: process.env.GRAFANA_SA_PASSWORD ?? "",

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -25,7 +25,7 @@
         "GRAFANA_WEBHOOK_API_TOKEN",
         "GRAFANA_SA_USERNAME",
         "GRAFANA_SA_PASSWORD",
-        "GRAFANA_URL"
+        "INTERNAL_GRAFANA_URL"
       ]
     }
   }


### PR DESCRIPTION
fix #160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment variable for Grafana API connections to use a new base URL across relevant features.
  - Adjusted development configuration to reflect the updated environment variable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->