### PR TITLE
drop metrics from bgrewrite job pods

### DIFF
--- a/argocd/app_plane/dev/alloy.yaml
+++ b/argocd/app_plane/dev/alloy.yaml
@@ -352,8 +352,8 @@ spec:
                     }
 
                     rule {
-                      source_labels = ["app"]
-                      regex         = "^(bgrewriteaof-job)"
+                      source_labels = ["pod"]
+                      regex         = "^(bgrewriteaof-instance.*)"
                       action        = "drop"
                     }
 

--- a/argocd/app_plane/dev/alloy.yaml
+++ b/argocd/app_plane/dev/alloy.yaml
@@ -351,6 +351,12 @@ spec:
                       action        = "keep"
                     }
 
+                    rule {
+                      source_labels = ["app"]
+                      regex         = "^(bgrewriteaof-job)"
+                      action        = "drop"
+                    }
+
                   }
 
                   prometheus.relabel "add_cluster_label" {


### PR DESCRIPTION
fix #233 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring configuration to exclude metrics from pods matching a specific pattern, reducing unwanted data in metric collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->