### PR TITLE
set clusterAdmin for argocd sa

### DIFF
--- a/tofu/gcp/org/workloads/application_plane/main.tf
+++ b/tofu/gcp/org/workloads/application_plane/main.tf
@@ -106,6 +106,6 @@ resource "google_storage_bucket_iam_member" "omnistrate_metering_data" {
 
 resource "google_project_iam_member" "argocd_sa_k8s_dev" {
   project = module.project.project_id
-  role    = "roles/container.developer"
+  role    = "roles/container.clusterAdmin"
   member  = "serviceAccount:${var.argocd_sa_email}"
 }


### PR DESCRIPTION
fix #251 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved ArgoCD sync/deployment failures caused by insufficient permissions on the development cluster.
* **Chores**
  * Updated service account permissions for ArgoCD to enable reliable cluster administration operations in development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->