### PR TITLE
fail import task if unable to continue

### DIFF
--- a/backend/services/db-importer/src/routes/import/controllers/ImportRDBController.ts
+++ b/backend/services/db-importer/src/routes/import/controllers/ImportRDBController.ts
@@ -195,12 +195,22 @@ export class ImportRDBController {
       throw ApiError.internalServerError("Error creating task", 'TASK_CREATION_ERROR');
     }
 
-    const uploadUrl = await this.storageRepository.getWriteUrl(
-      this._importBucketName,
-      payload.fileName,
-      'application/octet-stream',
-      60 * 60, // 1 hour
-    );
+    let uploadUrl = '';
+    try {
+      uploadUrl = await this.storageRepository.getWriteUrl(
+        this._importBucketName,
+        payload.fileName,
+        'application/octet-stream',
+        60 * 60, // 1 hour
+      );
+    } catch (error) {
+      await this.tasksRepository.updateTask({
+        taskId: task.taskId,
+        status: 'failed',
+        error: 'Internal error'
+      })
+      throw error;
+    }
 
     await this.tasksRepository.updateTask({
       taskId: task.taskId,


### PR DESCRIPTION
fix #253 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Import tasks now correctly report failure if the upload link cannot be created, preventing stuck “pending” states and reducing confusion. Clearer error messaging is shown, enabling easier retry.

* **Reliability**
  * Improved error handling during import setup to stop processing when upload initialization fails, ensuring consistent task state updates and avoiding silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->