### PR TITLE
feat: add GKE backup plan resource with schedule and retention policy

### DIFF
--- a/tofu/gcp/observability_stack/control_plane/infra/main.tf
+++ b/tofu/gcp/observability_stack/control_plane/infra/main.tf
@@ -202,6 +202,36 @@ resource "google_container_node_pool" "public" {
 
 }
 
+resource "google_gke_backup_backup_plan" "backup_plan" {
+  name     = "ctrl-plane-backup-plan"
+  project  = var.project_id
+  location = var.region
+  cluster  = module.gke.name
+
+  backup_config {
+    include_volume_data = true
+    include_secrets     = true
+    selected_namespaces {
+      namespaces = [
+        "api",
+        "observability",
+        "argocd",
+        "customer-observability",
+        "crossplane-system",
+        "sealed-secrets",
+      ]
+    }
+  }
+
+  backup_schedule {
+    cron_schedule = "0 1 * * *" # Daily at 1 AM UTC
+  }
+  retention_policy {
+    backup_retain_days      = 3
+    backup_delete_lock_days = 1
+  }
+}
+
 # ArgoCD IP Address
 module "argocd_ip" {
   source  = "terraform-google-modules/address/google"


### PR DESCRIPTION
fix #278 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated daily backups for the Kubernetes cluster at 01:00 UTC.
  * Backups include persistent volume data and secrets.
  * Applies to namespaces: api, observability, argocd, customer-observability, crossplane-system, sealed-secrets.
  * Retention policy keeps backups for 3 days with a 1-day delete lock to prevent accidental removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->