### PR TITLE
fix: set prune option to false in vmusers.yaml for both dev and prod

### DIFF
--- a/argocd/ctrl_plane/dev/vmusers.yaml
+++ b/argocd/ctrl_plane/dev/vmusers.yaml
@@ -52,5 +52,5 @@ spec:
         syncOptions:
           - CreateNamespace=true
         automated:
-          prune: true
+          prune: false
           selfHeal: false

--- a/argocd/ctrl_plane/prod/vmusers.yaml
+++ b/argocd/ctrl_plane/prod/vmusers.yaml
@@ -52,5 +52,5 @@ spec:
         syncOptions:
           - CreateNamespace=true
         automated:
-          prune: true
+          prune: false
           selfHeal: false


### PR DESCRIPTION
fix #318 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated resource pruning during synchronization in development and production environments, providing more granular control over resource management during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->