### PR TITLE
feat: add alert for KubePodFailedScheduling to monitor pod scheduling issues

### DIFF
--- a/observability/rules/kube-state-metrics.rules.yml
+++ b/observability/rules/kube-state-metrics.rules.yml
@@ -64,3 +64,14 @@ spec:
           labels:
             severity: critical
             cluster: '{{ $labels.cluster }}'
+        - alert: KubePodFailedScheduling
+          annotations:
+            description: '[cluster={{ $labels.cluster }}] Pod {{ $labels.namespace }}/{{ $labels.pod }} is failing to schedule due to: {{ $labels.reason }}.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready
+            summary: Pod is failing to schedule.
+          expr: |-
+            kube_pod_status_reason{job="kube-state-metrics", reason=~"FailedScheduling|Unschedulable"} == 1
+          for: 10m
+          labels:
+            severity: warning
+            cluster: '{{ $labels.cluster }}'


### PR DESCRIPTION
fix #162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new alert to detect pod scheduling failures in Kubernetes clusters, enabling early identification of cluster capacity or configuration issues with a 10-minute evaluation window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->