### PR TITLE
fix: add X-Org-ID header to auth proxy configuration in grafana ingress

### DIFF
--- a/argocd/ctrl_plane/prod/manifests/customer-grafana-ingresses.yaml
+++ b/argocd/ctrl_plane/prod/manifests/customer-grafana-ingresses.yaml
@@ -11,6 +11,7 @@ metadata:
       proxy_set_header Authorization $http_authorization;
       proxy_set_header X-WEBAUTH-USER $http_x_webauth_user;
       proxy_set_header Cookie $http_cookie;
+      proxy_set_header X-Org-ID $arg_orgId;
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     kubernetes.io/ingress.global-static-ip-name: 'customer-observability-ip'
 spec:


### PR DESCRIPTION
fix #327 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated infrastructure configuration to enhance organization-level request routing in Grafana authentication layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->