### PR TITLE
add link to view logs

### DIFF
--- a/observability/rules/containeroom.rules.yml
+++ b/observability/rules/containeroom.rules.yml
@@ -22,3 +22,5 @@ spec:
             summary: "Container OOMKilled"
             description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} was terminated due to OOMKilled."
             runbook_url: "https://github.com/FalkorDB/runbooks/blob/main/alerts/ContainerOOMKilledRunbook.md"
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}

--- a/observability/rules/containerrestarts.rules.yml
+++ b/observability/rules/containerrestarts.rules.yml
@@ -39,6 +39,8 @@ spec:
           annotations:
             summary: "Pod Restart Info"
             description: "[cluster={{ $labels.cluster }}] Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} restarted 10 or more times in the last hour. Investigate potential instability."
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
 
         # Warning Alert: Pods restarting 2+ times in 5 minutes
         - alert: PodRestartWarning
@@ -51,6 +53,8 @@ spec:
           annotations:
             summary: "Pod Restart Warning"
             description: "[cluster={{ $labels.cluster }}] Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} restarted at least 2 times in the last 5 minutes."
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
 
         - alert: PodRestartCritical
           expr: |
@@ -62,6 +66,8 @@ spec:
           annotations:
             summary: "Pod Restart Critical"
             description: "[cluster={{ $labels.cluster }}] Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} restarted 5 or more times in the last 10 minutes. Possible crash-loop detected."
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
 
         - alert: PodRestartWarning24H
           expr: |
@@ -73,4 +79,6 @@ spec:
           annotations:
             summary: "Pod Restart Warning 24H"
             description: "[cluster={{ $labels.cluster }}] Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} restarted 5 or more times in the last 24 hours. Investigate potential instability."
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
 

--- a/observability/rules/kube-state-metrics.rules.yml
+++ b/observability/rules/kube-state-metrics.rules.yml
@@ -69,6 +69,8 @@ spec:
             description: '[cluster={{ $labels.cluster }}] Pod {{ $labels.namespace }}/{{ $labels.pod }} is failing to schedule due to: {{ $labels.reason }}.'
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready
             summary: Pod is failing to schedule.
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
           expr: |-
             kube_pod_status_reason{job="kube-state-metrics", reason=~"FailedScheduling|Unschedulable"} == 1
           for: 10m

--- a/observability/rules/kubernetes-apps.rules.yml
+++ b/observability/rules/kubernetes-apps.rules.yml
@@ -17,6 +17,8 @@ spec:
             description: '[cluster={{ $labels.cluster }}] Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state (reason: "CrashLoopBackOff").'
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping
             summary: Pod is crash looping.
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
           expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", job="kube-state-metrics", namespace=~".*"}[5m]) >= 1
           for: 15m
           labels:
@@ -27,6 +29,8 @@ spec:
             description: '[cluster={{ $labels.cluster }}] Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.'
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready
             summary: Pod has been in a non-ready state for more than 15 minutes.
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
           expr: |-
             sum by (namespace,pod,cluster) (
               max by (namespace,pod,cluster) (
@@ -180,6 +184,8 @@ spec:
             description: '[cluster={{ $labels.cluster }}] pod/{{ $labels.pod }} in namespace {{ $labels.namespace }} on container {{ $labels.container}} has been in waiting state for longer than 1 hour. (reason: "{{ $labels.reason }}").'
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontainerwaiting
             summary: Pod container waiting longer than 1 hour
+            view_logs_prod: https://grafana.observability.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
+            view_logs_dev: https://grafana.observability.dev.internal.falkordb.cloud/explore?orgId=1&left={%22datasource%22:%22VictoriaLogs%22,%22queries%22:[{%22expr%22:%22pod:%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace:%5C%22{{ $labels.namespace }}%5C%22%22}],%22range%22:{%22from%22:%22{{ (index .Alerts 0).StartsAt.Add -300000000000 | date "2006-01-02T15:04:05Z" }}%22,%22to%22:%22now%22}}
           expr: kube_pod_container_status_waiting_reason{reason!="CrashLoopBackOff", job="kube-state-metrics", namespace=~".*"} > 0
           for: 1h
           labels:


### PR DESCRIPTION
fix #356 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated direct Grafana log viewing links for production and development environments into multiple container and pod observability alerts. Users can now access pod and container logs directly from alert notifications for container out-of-memory events, pod restart tracking, failed scheduling, crash loop detection, unready pod states, and container waiting conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->