### PR TITLE
feat: add domain to admin email mapping and groups to dex configuration

### DIFF
--- a/tofu/gcp/observability_stack/control_plane/k8s/values/dev/argocd.yaml
+++ b/tofu/gcp/observability_stack/control_plane/k8s/values/dev/argocd.yaml
@@ -46,6 +46,10 @@ configs:
           clientSecret: $dex.google.clientSecret
           serviceAccountFilePath: /tmp/oidc/googleAuth.json
           adminEmail: $dex.google.adminEmail
+          domainToAdminEmail: 
+            falkordb.com: $dex.google.adminEmail
+          groups:
+            - devops@falkordb.com
           fetchTransitiveGroupMembership: True
           scopes:
             - openid

--- a/tofu/gcp/observability_stack/control_plane/k8s/values/prod/argocd.yaml
+++ b/tofu/gcp/observability_stack/control_plane/k8s/values/prod/argocd.yaml
@@ -46,6 +46,10 @@ configs:
           clientSecret: $dex.google.clientSecret
           serviceAccountFilePath: /tmp/oidc/googleAuth.json
           adminEmail: $dex.google.adminEmail
+          domainToAdminEmail: 
+            falkordb.com: $dex.google.adminEmail
+          groups:
+            - devops@falkordb.com
           fetchTransitiveGroupMembership: True
           scopes:
             - openid


### PR DESCRIPTION
fix #382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration across development and production environments to enable domain-based admin email routing and implement group membership verification for enhanced permission management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->