### PR TITLE
fix: update authentication type from oidc to google in argocd configuration

### DIFF
--- a/tofu/gcp/observability_stack/control_plane/k8s/values/dev/argocd.yaml
+++ b/tofu/gcp/observability_stack/control_plane/k8s/values/dev/argocd.yaml
@@ -57,7 +57,7 @@ configs:
             - profile
             - https://www.googleapis.com/auth/admin.directory.group.readonly
             - https://www.googleapis.com/auth/admin.directory.user.readonly
-        type: oidc
+        type: google
         id: google
         name: Google
   rbac:

--- a/tofu/gcp/observability_stack/control_plane/k8s/values/prod/argocd.yaml
+++ b/tofu/gcp/observability_stack/control_plane/k8s/values/prod/argocd.yaml
@@ -57,7 +57,7 @@ configs:
             - profile
             - https://www.googleapis.com/auth/admin.directory.group.readonly
             - https://www.googleapis.com/auth/admin.directory.user.readonly
-        type: oidc
+        type: google
         id: google
         name: Google
   rbac:


### PR DESCRIPTION
fix #382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google identity provider connector configuration in ArgoCD for development and production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->