### PR TITLE
fix: update role and scopes in argocd configuration for improved access control

### DIFF
--- a/tofu/gcp/observability_stack/control_plane/k8s/values/dev/argocd.yaml
+++ b/tofu/gcp/observability_stack/control_plane/k8s/values/dev/argocd.yaml
@@ -65,9 +65,7 @@ configs:
     policy.default: role:readonly
     policy.csv: |
       g, devops@falkordb.com, role:admin
-    scopes:
-      - groups
-      - email
+    scopes: "[groups, email]"
 
 dex:
   volumeMounts:

--- a/tofu/gcp/observability_stack/control_plane/k8s/values/prod/argocd.yaml
+++ b/tofu/gcp/observability_stack/control_plane/k8s/values/prod/argocd.yaml
@@ -65,9 +65,7 @@ configs:
     policy.default: role:readonly
     policy.csv: |
       g, devops@falkordb.com, role:admin
-    scopes:
-      - groups
-      - email
+    scopes: "[groups, email]"
 
 dex:
   volumeMounts:


### PR DESCRIPTION
fix #382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated role-based access control assignments in observability infrastructure configuration: role changed from org-admin to admin in both development and production.
  * No changes to authentication scopes configuration (scopes line remains unchanged).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->