### PR TITLE
fix: refine Redis crash detection to exclude vmalert pods

### DIFF
--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -78,7 +78,7 @@ spec:
           # LogsQL: Detect Redis crash by signal
           # Triggers when Redis crashes with a signal, which indicates a critical failure
           expr: |
-            ~"Redis .+ crashed by signal" and pod:!="vmalert*" | 
+            ~"Redis .+ crashed by signal" and -pod:~"vmalert*" | 
             stats by (pod, namespace, cluster) count() as crash_count    
           for: 0m
           labels:


### PR DESCRIPTION
fix #390 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined Redis crash alerting to reduce false positives by excluding monitoring/alerting pods from crash counts. Alerts now aggregate crash events per pod/namespace/cluster so notifications focus on relevant application instances and avoid noisy signals from internal monitoring processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->