### PR TITLE
fix: update cluster-discovery image version to 1.2.1

### DIFF
--- a/argocd/kustomize/cluster-discovery/overlays/prod/kustomization.yaml
+++ b/argocd/kustomize/cluster-discovery/overlays/prod/kustomization.yaml
@@ -16,7 +16,7 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: "us-central1-docker.pkg.dev/ctrl-plane-prod-b1b92df2/backend/cluster-discovery:1.1.2"
+        value: "us-central1-docker.pkg.dev/ctrl-plane-prod-b1b92df2/backend/cluster-discovery:1.2.1"
       - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: "IfNotPresent"


### PR DESCRIPTION
fix #603 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the cluster-discovery service to version 1.2.1 in the production environment. This important service upgrade brings the latest performance improvements and key enhancements. The update ensures optimal reliability, consistent performance, and stability for cluster discovery operations in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->