### PR TITLE
switch to workload identity

### DIFF
--- a/.github/workflows/rdb-uploader.yml
+++ b/.github/workflows/rdb-uploader.yml
@@ -10,6 +10,7 @@ name: RDB Uploader
 
 permissions:
   contents: read
+  id-token: write
   issues: write
 
 on:
@@ -163,7 +164,16 @@ jobs:
           echo "KUBECONFIG=/tmp/kubeconfig" >> $GITHUB_ENV
 
       # ------------------------------------------------------------------ #
-      # 6. Run rdb_uploader.py — handles signing, kubectl exec, and outputs
+      # 6. Authenticate to GCP via Workload Identity Federation
+      # ------------------------------------------------------------------ #
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCS_SA_EMAIL }}
+
+      # ------------------------------------------------------------------ #
+      # 7. Run rdb_uploader.py — handles signing, kubectl exec, and outputs
       # ------------------------------------------------------------------ #
       - name: Upload RDB (and AOF) from pod to GCS
         id: upload_gcs
@@ -173,7 +183,7 @@ jobs:
           CONTAINER: ${{ inputs.container }}
           SIGN_ONLY: ${{ inputs.sign_only }}
           GCS_BUCKET: ${{ vars.GCS_BUCKET }}
-          GCS_SA_KEY: ${{ secrets.GCP_BUCKET_SA_KEY }}
+          GCS_SA_EMAIL: ${{ vars.GCS_SA_EMAIL }}
         run: |
           EXTRA_ARGS=()
           [[ "${SIGN_ONLY,,}" == "true" ]] && EXTRA_ARGS+=("--sign-only")
@@ -185,7 +195,7 @@ jobs:
             "${EXTRA_ARGS[@]}"
 
       # ------------------------------------------------------------------ #
-      # 7. Comment download links on the GitHub issue
+      # 8. Comment download links on the GitHub issue
       # ------------------------------------------------------------------ #
       - name: Comment download links on issue
         if: ${{ inputs.issue_number != '' }}

--- a/.github/workflows/rdb-uploader.yml
+++ b/.github/workflows/rdb-uploader.yml
@@ -169,8 +169,8 @@ jobs:
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCS_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCS_SA_EMAIL }}
 
       # ------------------------------------------------------------------ #
       # 7. Run rdb_uploader.py — handles signing, kubectl exec, and outputs
@@ -183,7 +183,7 @@ jobs:
           CONTAINER: ${{ inputs.container }}
           SIGN_ONLY: ${{ inputs.sign_only }}
           GCS_BUCKET: ${{ vars.GCS_BUCKET }}
-          GCS_SA_EMAIL: ${{ vars.GCS_SA_EMAIL }}
+          GCS_SA_EMAIL: ${{ secrets.GCS_SA_EMAIL }}
         run: |
           EXTRA_ARGS=()
           [[ "${SIGN_ONLY,,}" == "true" ]] && EXTRA_ARGS+=("--sign-only")

--- a/.github/workflows/redis-crash-handler.yml
+++ b/.github/workflows/redis-crash-handler.yml
@@ -5,6 +5,7 @@ name: Redis Crash Handler
 
 permissions:
   contents: read
+  id-token: write
   issues: write
 
 on:

--- a/scripts/rdb_uploader.py
+++ b/scripts/rdb_uploader.py
@@ -10,38 +10,41 @@ Mirrors the logic of upload_to_gcp.sh.
 
 import os
 import sys
-import json
 import subprocess
 import argparse
 import datetime
 
-from google.oauth2 import service_account
+import google.auth
+import google.auth.transport.requests
 from google.cloud import storage
 
 
-def _load_credentials() -> service_account.Credentials:
-    """Parse GCS_SA_KEY once and return SA credentials."""
-    key_json = os.environ.get("GCS_SA_KEY")
-    if not key_json:
-        raise EnvironmentError("GCS_SA_KEY env var is not set")
-    return service_account.Credentials.from_service_account_info(
-        json.loads(key_json),
+def _load_credentials():
+    """Load Application Default Credentials (set by google-github-actions/auth)."""
+    credentials, project = google.auth.default(
         scopes=["https://www.googleapis.com/auth/cloud-platform"],
     )
+    # Refresh to obtain an access token (needed for IAM signBlob-based signing)
+    credentials.refresh(google.auth.transport.requests.Request())
+    return credentials
 
 
 def get_signed_url(
     blob: storage.Blob,
-    credentials: service_account.Credentials,
+    credentials,
     expiration_minutes: int,
     method: str = "GET",
 ) -> str:
-    """Generate a v4 signed URL for a GCS blob."""
+    """Generate a v4 signed URL for a GCS blob using IAM signBlob API."""
+    sa_email = os.environ.get("GCS_SA_EMAIL")
+    if not sa_email:
+        raise EnvironmentError("GCS_SA_EMAIL env var is not set")
     return blob.generate_signed_url(
         version="v4",
         expiration=datetime.timedelta(minutes=expiration_minutes),
         method=method,
-        credentials=credentials,
+        service_account_email=sa_email,
+        access_token=credentials.token,
     )
 
 

--- a/scripts/rdb_uploader.py
+++ b/scripts/rdb_uploader.py
@@ -21,7 +21,7 @@ from google.cloud import storage
 
 def _load_credentials():
     """Load Application Default Credentials (set by google-github-actions/auth)."""
-    credentials, project = google.auth.default(
+    credentials, _project = google.auth.default(
         scopes=["https://www.googleapis.com/auth/cloud-platform"],
     )
     # Refresh to obtain an access token (needed for IAM signBlob-based signing)

--- a/tofu/gcp/org/workloads/application_plane/main.tf
+++ b/tofu/gcp/org/workloads/application_plane/main.tf
@@ -158,3 +158,17 @@ resource "google_storage_bucket_iam_member" "rdb_bucket_sa_object_user" {
   role   = "roles/storage.objectUser"
   member = "serviceAccount:${google_service_account.rdb_bucket_sa.email}"
 }
+
+# Allow GitHub Actions workload identity to impersonate rdb_bucket_sa
+resource "google_service_account_iam_member" "rdb_bucket_sa_wi_user" {
+  service_account_id = google_service_account.rdb_bucket_sa.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${var.gh_workload_identity_pool_name}/attribute.repository/${var.repo_name}"
+}
+
+# Allow rdb_bucket_sa to sign blobs (required for generating signed URLs via IAM API)
+resource "google_service_account_iam_member" "rdb_bucket_sa_token_creator" {
+  service_account_id = google_service_account.rdb_bucket_sa.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.rdb_bucket_sa.email}"
+}

--- a/tofu/gcp/org/workloads/application_plane/variables.tf
+++ b/tofu/gcp/org/workloads/application_plane/variables.tf
@@ -39,3 +39,13 @@ variable "customer_rdb_bucket_name" {
 variable "argocd_sa_email" {
   type = string
 }
+
+variable "gh_workload_identity_pool_name" {
+  type        = string
+  description = "Full resource name of the GitHub Actions workload identity pool from the control plane project"
+}
+
+variable "repo_name" {
+  type        = string
+  description = "GitHub repository name (org/repo) for workload identity attribute condition"
+}

--- a/tofu/gcp/org/workloads/control_plane/outputs.tf
+++ b/tofu/gcp/org/workloads/control_plane/outputs.tf
@@ -10,6 +10,10 @@ output "gh_workload_identity_provider" {
   value = module.gh_oidc.provider_name
 }
 
+output "gh_workload_identity_pool_name" {
+  value = module.gh_oidc.pool_name
+}
+
 output "db_exporter_sa_email" {
   value = google_service_account.db_exporter_sa.email
 }

--- a/tofu/gcp/org/workloads/main.tf
+++ b/tofu/gcp/org/workloads/main.tf
@@ -49,6 +49,9 @@ module "application_plane" {
   db_exporter_sa_email = module.control_plane.db_exporter_sa_email
   argocd_sa_email      = module.control_plane.argocd_sa_email
 
+  gh_workload_identity_pool_name = module.control_plane.gh_workload_identity_pool_name
+  repo_name                      = var.pipelines_development_repo_name
+
   metering_bucket_name     = var.application_plane_metering_bucket_name
   customer_rdb_bucket_name = var.application_plane_customer_rdb_bucket_name
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflows updated to support Workload Identity Federation for GCP authentication.
  * Automated processes moved from service-account-key usage to Application Default Credentials.
  * GCP IAM and infrastructure updated to permit GitHub Actions to impersonate and obtain tokens for the bucket service account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->