### PR TITLE
fix: update min and max replicas for ldap-auth HorizontalPodAutoscaler

### DIFF
--- a/argocd/kustomize/ldap-auth/overlays/prod/kustomization.yaml
+++ b/argocd/kustomize/ldap-auth/overlays/prod/kustomization.yaml
@@ -53,10 +53,10 @@ patches:
     patch: |-
       - op: replace
         path: /spec/minReplicas
-        value: 1
+        value: 2
       - op: replace
         path: /spec/maxReplicas
-        value: 2
+        value: 3
   - target:
       kind: ConfigMap
       name: ldap-auth-config


### PR DESCRIPTION
fix #401 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production scaling configuration for the LDAP authentication service to enhance overall reliability, performance, and resource capacity resilience. Minimum service replicas increased from 1 to 2, and maximum replicas increased from 2 to 3. These changes improve service availability and enable better handling of traffic spikes and increased user demand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->