### PR TITLE
Added RedisClusterJoinStuck alert

### DIFF
--- a/observability/rules/falkordb.rules.yml
+++ b/observability/rules/falkordb.rules.yml
@@ -309,8 +309,4 @@ spec:
             cluster: '{{ $labels.cluster }}'
           annotations:
             summary: FalkorDB cluster flapping (instance {{ $labels.namespace }})
-<<<<<<< HEAD
             description: "[cluster={{ $labels.cluster }}] Changes have been detected in FalkorDB replica connection. This can occur when replica nodes lose connection to the master and reconnect (a.k.a flapping).\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-=======
-            description: "[cluster={{ $labels.cluster }}] Changes have been detected in FalkorDB replica connection. This can occur when replica nodes lose connection to the master and reconnect (a.k.a flapping).\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
->>>>>>> 97bb4c40f61bf0da05782b4d7723986dd5479526

--- a/observability/rules/falkordb.rules.yml
+++ b/observability/rules/falkordb.rules.yml
@@ -290,18 +290,3 @@ spec:
           annotations:
             summary: FalkorDB cluster flapping (instance {{ $labels.namespace }})
             description: "[cluster={{ $labels.cluster }}] Changes have been detected in FalkorDB replica connection. This can occur when replica nodes lose connection to the master and reconnect (a.k.a flapping).\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-
-        - alert: RedisClusterJoinStuck
-          # Fires when "Waiting for the cluster to join" is detected in logs (via recording rule)
-          # but no "CONFIG REWRITE executed with success" follows within the same 15m window.
-          # Recording rules are evaluated by vmalert-logs in vl-logs.rules.yml.
-          expr: redis_cluster_join_waiting > 0 unless on(pod, namespace) redis_cluster_join_success > 0
-          for: 10m
-          labels:
-            severity: warning
-            cluster: '{{ $labels.cluster }}'
-            environment: '{{ $labels.environment }}'
-          annotations:
-            summary: "Redis cluster join stuck in {{ $labels.pod }} ({{ $labels.namespace }})"
-            description: "[cluster={{ $labels.cluster }}] The pod '{{ $labels.pod }}' in namespace '{{ $labels.namespace }}' has been stuck in \"Waiting for the cluster to join\" for over 10 minutes. The CLUSTER MEET operation is not completing, which prevents the cluster from becoming operational. This typically requires manual investigation of network connectivity between nodes."
-            view_logs: 'https://grafana.observability{{ if eq $labels.environment "dev" }}.dev{{ end }}.internal.falkordb.cloud/explore?orgId=1&left=%7B%22datasource%22%3A%22VictoriaLogs%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22pod%3A%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace%3A%5C%22{{ $labels.namespace }}%5C%22%20AND%20container%3A%5C%22service%5C%22%22%7D%5D%7D'

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -101,10 +101,11 @@ spec:
           # During cluster creation, redis-cli prints dots while waiting for nodes to join.
           # A normal join completes in seconds. If lines consisting entirely of dots appear
           # and persist, the join is stuck at "Waiting for the cluster to join".
-          # The anchored regex ^\.{10,}$ avoids matching unrelated log lines that
-          # happen to contain dots embedded in other text.
+          # The anchored regex ^\\.{10,}$ avoids matching unrelated log lines that
+          # happen to contain dots embedded in other text. The double backslash is
+          # needed because the LogsQL double-quoted string consumes one level of escaping.
           expr: |
-            ~"^\.{10,}$" and namespace:~"instance-.*" and _time:5m |
+            ~"^\\.{10,}$" and namespace:~"instance-.*" and _time:5m |
             stats by (pod, namespace, cluster, environment) count() as dot_count |
             filter dot_count :> 0
           for: 2m

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -96,6 +96,31 @@ spec:
               Crash count: {{ $value }}.
             view_logs: 'https://grafana.observability{{ if eq $labels.environment "dev" }}.dev{{ end }}.internal.falkordb.cloud/explore?orgId=1&left=%7B%22datasource%22%3A%22VictoriaLogs%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22pod%3A%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace%3A%5C%22{{ $labels.namespace }}%5C%22%20AND%20container%3A%5C%22service%5C%22%22%7D%5D%7D'
 
+        - alert: RedisClusterJoinStuck
+          # LogsQL: Detect when a Redis cluster join is stuck.
+          # During cluster creation, redis-cli prints dots while waiting for nodes to join.
+          # A normal join completes in seconds. If lines consisting entirely of dots appear
+          # and persist, the join is stuck at "Waiting for the cluster to join".
+          # The anchored regex ^\.{10,}$ avoids matching unrelated log lines that
+          # happen to contain dots embedded in other text.
+          expr: |
+            ~"^\.{10,}$" and namespace:~"instance-.*" and _time:5m |
+            stats by (pod, namespace, cluster, environment) count() as dot_count |
+            filter dot_count :> 0
+          for: 2m
+          labels:
+            severity: critical
+            cluster: "{{ $labels.cluster }}"
+            environment: "{{ $labels.environment }}"
+          annotations:
+            summary: "Redis cluster join stuck in {{ $labels.pod }} ({{ $labels.namespace }})"
+            description: |
+              [cluster={{ $labels.cluster }}] Redis cluster join appears stuck in pod '{{ $labels.pod }}' 
+              in namespace '{{ $labels.namespace }}'. The cluster creation process is stuck at the 
+              "Waiting for the cluster to join" stage, indicating nodes cannot communicate properly.
+              Dot count: {{ $value }}.
+            view_logs: 'https://grafana.observability{{ if eq $labels.environment "dev" }}.dev{{ end }}.internal.falkordb.cloud/explore?orgId=1&left=%7B%22datasource%22%3A%22VictoriaLogs%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22pod%3A%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace%3A%5C%22{{ $labels.namespace }}%5C%22%22%7D%5D%7D'
+
         - alert: RedisCrashLoop
           # LogsQL: Detect Redis crash loop (2+ crashes in last 10 minutes).
           # Uses "=== REDIS BUG REPORT START" as the single anchor — it is emitted exactly once per

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -117,7 +117,3 @@ spec:
               is in a crash loop. It has crashed {{ $value }} times in the last 10 minutes.
               This requires immediate attention to prevent service disruption.
             view_logs: 'https://grafana.observability{{ if eq $labels.environment "dev" }}.dev{{ end }}.internal.falkordb.cloud/explore?orgId=1&left=%7B%22datasource%22%3A%22VictoriaLogs%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22pod%3A%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace%3A%5C%22{{ $labels.namespace }}%5C%22%20AND%20container%3A%5C%22service%5C%22%22%7D%5D%7D'
-<<<<<<< HEAD
-=======
-
->>>>>>> 97bb4c40f61bf0da05782b4d7723986dd5479526

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -99,13 +99,11 @@ spec:
         - alert: RedisClusterJoinStuck
           # LogsQL: Detect when a Redis cluster join is stuck.
           # During cluster creation, redis-cli prints dots while waiting for nodes to join.
-          # A normal join completes in seconds. If lines consisting entirely of dots appear
+          # A normal join completes in seconds. If lines with 10+ consecutive dots appear
           # and persist, the join is stuck at "Waiting for the cluster to join".
-          # The anchored regex ^\\.{10,}$ avoids matching unrelated log lines that
-          # happen to contain dots embedded in other text. The double backslash is
-          # needed because the LogsQL double-quoted string consumes one level of escaping.
+          # No anchors (^/$) because the log message may include a container runtime prefix.
           expr: |
-            ~"^\\.{10,}$" and namespace:~"instance-.*" and _time:5m |
+            ~"\\.{10,}" and namespace:~"instance-.*" and _time:5m |
             stats by (pod, namespace, cluster, environment) count() as dot_count |
             filter dot_count :> 0
           for: 2m

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -102,8 +102,10 @@ spec:
           # A normal join completes in seconds. If lines with 10+ consecutive dots appear
           # and persist, the join is stuck at "Waiting for the cluster to join".
           # No anchors (^/$) because the log message may include a container runtime prefix.
+          # _time:1m keeps the window short so a single dot-line from a fast successful
+          # join cannot persist across the 2m `for` clause and cause a false positive.
           expr: |
-            ~"\\.{10,}" and namespace:~"instance-.*" and _time:5m |
+            ~"\\.{10,}" and namespace:~"instance-.*" and _time:1m |
             stats by (pod, namespace, cluster, environment) count() as dot_count |
             filter dot_count :> 0
           for: 2m

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -105,7 +105,7 @@ spec:
           # happen to contain dots embedded in other text. The double backslash is
           # needed because the LogsQL double-quoted string consumes one level of escaping.
           expr: |
-            ~"^\\.{5,}$" and namespace:~"instance-.*" and _time:5m |
+            ~"^\\.{10,}$" and namespace:~"instance-.*" and _time:5m |
             stats by (pod, namespace, cluster, environment) count() as dot_count |
             filter dot_count :> 0
           for: 2m

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -117,17 +117,3 @@ spec:
               is in a crash loop. It has crashed {{ $value }} times in the last 10 minutes.
               This requires immediate attention to prevent service disruption.
             view_logs: 'https://grafana.observability{{ if eq $labels.environment "dev" }}.dev{{ end }}.internal.falkordb.cloud/explore?orgId=1&left=%7B%22datasource%22%3A%22VictoriaLogs%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22pod%3A%5C%22{{ $labels.pod }}%5C%22%20AND%20namespace%3A%5C%22{{ $labels.namespace }}%5C%22%20AND%20container%3A%5C%22service%5C%22%22%7D%5D%7D'
-
-        # Recording rule: counts "Waiting for the cluster to join" log lines per pod in the last 15m.
-        # Used by the RedisClusterJoinStuck PromQL alert in falkordb.rules.yml.
-        - record: redis_cluster_join_waiting
-          expr: |
-            ~"Waiting for the cluster to join" and namespace:~"instance-.*" and _time:15m |
-            stats by (pod, namespace, cluster, environment) count() as join_wait_count
-
-        # Recording rule: counts "CONFIG REWRITE executed with success" log lines per pod in the last 15m.
-        # Presence of this line indicates the cluster join completed successfully.
-        - record: redis_cluster_join_success
-          expr: |
-            ~"CONFIG REWRITE executed with success" and namespace:~"instance-.*" and _time:15m |
-            stats by (pod, namespace, cluster, environment) count() as success_count

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -105,7 +105,7 @@ spec:
           # happen to contain dots embedded in other text. The double backslash is
           # needed because the LogsQL double-quoted string consumes one level of escaping.
           expr: |
-            ~"^\\.{10,}$" and namespace:~"instance-.*" and _time:5m |
+            ~"^\\.{5,}$" and namespace:~"instance-.*" and _time:5m |
             stats by (pod, namespace, cluster, environment) count() as dot_count |
             filter dot_count :> 0
           for: 2m

--- a/observability/rules/vl-logs.rules.yml
+++ b/observability/rules/vl-logs.rules.yml
@@ -102,12 +102,10 @@ spec:
           # A normal join completes in seconds. If lines with 10+ consecutive dots appear
           # and persist, the join is stuck at "Waiting for the cluster to join".
           # No anchors (^/$) because the log message may include a container runtime prefix.
-          # _time:1m keeps the window short so a single dot-line from a fast successful
-          # join cannot persist across the 2m `for` clause and cause a false positive.
           expr: |
-            ~"\\.{10,}" and namespace:~"instance-.*" and _time:1m |
+            ~"\\.{10,}" and namespace:~"instance-.*" and _time:2m |
             stats by (pod, namespace, cluster, environment) count() as dot_count |
-            filter dot_count :> 0
+            filter dot_count :> 1
           for: 2m
           labels:
             severity: critical

--- a/scripts/rdb_uploader.py
+++ b/scripts/rdb_uploader.py
@@ -185,11 +185,12 @@ def detect_falkordb_version(namespace: str, pod: str, container: str) -> str:
     If the first attempt fails (e.g. Redis is down after a crash), waits for
     the pod to become Ready and retries once.
     """
-    output = kubectl_exec_output(namespace, pod, container, ["redis-cli", "MODULE", "LIST"])
+    cmd = ["sh", "-c", "cat /run/secrets/adminpassword | xargs -I {} redis-cli -a {} --no-auth-warning MODULE LIST"]
+    output = kubectl_exec_output(namespace, pod, container, cmd)
     if not output:
         print("  ⚠️  Could not retrieve MODULE LIST — waiting for pod to be Ready and retrying...")
         kubectl_wait_pod_ready(namespace, pod)
-        output = kubectl_exec_output(namespace, pod, container, ["redis-cli", "MODULE", "LIST"])
+        output = kubectl_exec_output(namespace, pod, container, cmd)
     if not output:
         print("  ⚠️  Could not retrieve MODULE LIST after retry — version unknown")
         return ""

--- a/scripts/rdb_uploader.py
+++ b/scripts/rdb_uploader.py
@@ -185,7 +185,7 @@ def detect_falkordb_version(namespace: str, pod: str, container: str) -> str:
     If the first attempt fails (e.g. Redis is down after a crash), waits for
     the pod to become Ready and retries once.
     """
-    cmd = ["sh", "-c", "cat /run/secrets/adminpassword | xargs -I {} redis-cli -a {} --no-auth-warning MODULE LIST"]
+    cmd = ["sh", "-c", "export REDISCLI_AUTH=$(cat /run/secrets/adminpassword) && redis-cli --no-auth-warning MODULE LIST"]
     output = kubectl_exec_output(namespace, pod, container, cmd)
     if not output:
         print("  ⚠️  Could not retrieve MODULE LIST — waiting for pod to be Ready and retrying...")

--- a/scripts/redis_crash_handler.py
+++ b/scripts/redis_crash_handler.py
@@ -1051,7 +1051,7 @@ class GoogleChatNotifier:
     ):
         """Send error notification to Google Chat"""
         payload = {
-            "text": "❌ Redis Crash Handler Failed <users/roi.lipman@falkordb.com> <users/avi.avni@falkordb.com>",
+            "text": "❌ Redis Crash Handler Failed <users/1> <users/2>",
             "cards": [{
                 "header": {
                     "title": "❌ Redis Crash Handler Failed",
@@ -1113,7 +1113,7 @@ class GoogleChatNotifier:
             subtitle = f"Customer: {customer_email}"
         
         payload = {
-            "text": f"{crash_type} <users/roi.lipman@falkordb.com> <users/avi.avni@falkordb.com>",
+            "text": f"{crash_type} <users/1> <users/2>",
             "cards": [{
                 "header": {
                     "title": crash_type,
@@ -1199,7 +1199,7 @@ class GoogleChatNotifier:
         crash notifications.
         """
         payload = {
-            "text": "🔁 Recurring Redis Crash <users/roi.lipman@falkordb.com> <users/avi.avni@falkordb.com>",
+            "text": "🔁 Recurring Redis Crash <users/1> <users/2>",
             "cards": [{
                 "header": {
                     "title": "🔁 Recurring Redis Crash",

--- a/scripts/redis_crash_handler.py
+++ b/scripts/redis_crash_handler.py
@@ -1051,7 +1051,7 @@ class GoogleChatNotifier:
     ):
         """Send error notification to Google Chat"""
         payload = {
-            "text": "❌ Redis Crash Handler Failed <users/1> <users/2>",
+            "text": "❌ Redis Crash Handler Failed <users/116170488112818253188> <users/115942454099354054771>",
             "cards": [{
                 "header": {
                     "title": "❌ Redis Crash Handler Failed",
@@ -1113,7 +1113,7 @@ class GoogleChatNotifier:
             subtitle = f"Customer: {customer_email}"
         
         payload = {
-            "text": f"{crash_type} <users/1> <users/2>",
+            "text": f"{crash_type} <users/116170488112818253188> <users/115942454099354054771>",
             "cards": [{
                 "header": {
                     "title": crash_type,
@@ -1199,7 +1199,7 @@ class GoogleChatNotifier:
         crash notifications.
         """
         payload = {
-            "text": "🔁 Recurring Redis Crash <users/1> <users/2>",
+            "text": "🔁 Recurring Redis Crash <users/116170488112818253188> <users/115942454099354054771>",
             "cards": [{
                 "header": {
                     "title": "🔁 Recurring Redis Crash",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a critical alert for Redis cluster join issues in Kubernetes, firing after 2 minutes with templated cluster/environment labels and a Grafana log viewer link.

* **Chores**
  * Updated notification text formatting for chat alerts.
  * Redis tooling now uses the stored admin password when invoking CLI commands to authenticate securely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->