### PR TITLE
fix: security hardening and reliability improvements for OOM triage p…

### DIFF
--- a/.github/workflows/oom-handler.yml
+++ b/.github/workflows/oom-handler.yml
@@ -52,7 +52,26 @@ jobs:
           echo "Environment is 'dev' — OOMKilled event noted."
           echo "Pod: ${{ inputs.pod }}, Namespace: ${{ inputs.namespace }}, Container: ${{ inputs.container }}"
 
+  check-authorised-actor:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.environment != 'dev' || inputs.test }}
+    steps:
+      - name: Check authorised actor
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          ALLOWED_USERS=("swilly22" "MuhammadQadora" "dudizimber" "AviAvni" "barakb")
+          for user in "${ALLOWED_USERS[@]}"; do
+            if [[ "$ACTOR" == "$user" ]]; then
+              echo "Actor '$ACTOR' is authorised. Proceeding."
+              exit 0
+            fi
+          done
+          echo "Actor '$ACTOR' is not authorised to run this workflow."
+          exit 1
+
   analyze-oom:
+    needs: check-authorised-actor
     runs-on: ubuntu-latest
     if: ${{ inputs.environment != 'dev' || inputs.test }}
     outputs:
@@ -113,7 +132,7 @@ jobs:
             --grafana-url "$GRAFANA_URL"
 
   upload-rdb:
-    needs: analyze-oom
+    needs: [analyze-oom, check-authorised-actor]
     if: ${{ needs.analyze-oom.outputs.customer_name != '' }}
     uses: ./.github/workflows/rdb-uploader.yml
     secrets: inherit
@@ -125,25 +144,11 @@ jobs:
       environment: ${{ inputs.environment }}
 
   ai-oom-triage:
-    needs: [analyze-oom, upload-rdb]
-    if: ${{ always() && needs.analyze-oom.outputs.customer_name != '' }}
+    needs: [analyze-oom, upload-rdb, check-authorised-actor]
+    if: ${{ always() && needs.analyze-oom.outputs.customer_name != '' && needs.check-authorised-actor.result == 'success' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - name: Check authorised actor
-        env:
-          ACTOR: ${{ github.actor }}
-        run: |
-          ALLOWED_USERS=("swilly22" "MuhammadQadora" "dudizimber" "AviAvni" "barakb")
-          for user in "${ALLOWED_USERS[@]}"; do
-            if [[ "$ACTOR" == "$user" ]]; then
-              echo "Actor '$ACTOR' is authorised. Proceeding."
-              exit 0
-            fi
-          done
-          echo "Actor '$ACTOR' is not authorised to run this workflow."
-          exit 1
-
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 

--- a/scripts/ai_oom_triage.py
+++ b/scripts/ai_oom_triage.py
@@ -201,6 +201,19 @@ def _mask_email(email: str) -> str:
     return f"{masked_local}@{domain}"
 
 
+# Regex to detect GCS signed URLs (contain X-Goog-Signature or Signature query params)
+_SIGNED_URL_RE = re.compile(
+    r'https://storage\.googleapis\.com/[^\s"\'<>]+(?:X-Goog-Signature|Signature)=[^\s"\'<>]+'
+)
+
+
+def _scrub_report(text: str) -> str:
+    """Scrub PII and sensitive content from a report before logging/sending."""
+    text = _EMAIL_RE.sub(lambda m: _mask_email(m.group(0)), text)
+    text = _SIGNED_URL_RE.sub("[SIGNED-URL-REDACTED]", text)
+    return text
+
+
 def _build_initial_prompt(args) -> str:
     """Build the initial prompt with OOM context for the AI session."""
     prompt = f"""\
@@ -226,7 +239,7 @@ A ContainerOOMKilled event has been detected. Please perform a full OOM triage.
 When querying metrics, use these label selectors:
 - namespace="{args.namespace}"
 - pod="{args.pod}"
-- container="service" (for Redis metrics)
+- container="{args.container}" (for Redis metrics)
 
 Start with Step 1: query the 7-day memory trend, then proceed through all steps.
 """
@@ -287,12 +300,12 @@ def _send_report_to_chat(
     """Send the AI triage report as a Google Chat card."""
 
     # Extract key fields from the report
-    category = _extract_report_field(report, "Category") or "Unknown"
-    confidence = _extract_report_field(report, "Confidence") or "Unknown"
-    seven_day_trend = _extract_report_field(report, "7-day trend") or "N/A"
-    memory_at_oom = _extract_report_field(report, "Memory at OOM") or "N/A"
-    maxmemory = _extract_report_field(report, "Maxmemory config") or "N/A"
-    command_rate = _extract_report_field(report, "Command rate before OOM") or "N/A"
+    category = html.escape(_extract_report_field(report, "Category") or "Unknown")
+    confidence = html.escape(_extract_report_field(report, "Confidence") or "Unknown")
+    seven_day_trend = html.escape(_extract_report_field(report, "7-day trend") or "N/A")
+    memory_at_oom = html.escape(_extract_report_field(report, "Memory at OOM") or "N/A")
+    maxmemory = html.escape(_extract_report_field(report, "Maxmemory config") or "N/A")
+    command_rate = html.escape(_extract_report_field(report, "Command rate before OOM") or "N/A")
 
     # Extract the Recommended Action section
     recommended_action = ""
@@ -373,8 +386,8 @@ def _send_report_to_chat(
         response.raise_for_status()
         print("AI triage card sent to Google Chat.")
 
-        # Send full report as a follow-up message — scrub emails for PII safety
-        scrubbed_report = _EMAIL_RE.sub(lambda m: _mask_email(m.group(0)), report)
+        # Send full report as a follow-up message — scrub PII and sensitive URLs
+        scrubbed_report = _scrub_report(report)
         full_report_payload = {
             "text": f"📋 *Full AI OOM Triage Report — {pod} ({namespace})*\n\n{scrubbed_report}",
         }
@@ -469,6 +482,7 @@ def main():
     parser.add_argument("--rdb-url", default="", help="GCS path for dump.rdb")
     parser.add_argument("--aof-url", default="", help="GCS path for appendonlydir.tar.gz")
     parser.add_argument("--falkordb-version", default="", help="FalkorDB version")
+    parser.add_argument("--alert-timestamp", default="", help="ISO timestamp of the OOM event (fallback: now)")
     args = parser.parse_args()
 
     # Pass vmauth-url to tools via env
@@ -480,7 +494,15 @@ def main():
     verify_ssl = not (environment == "dev" or disable_ssl_verify)
 
     # Generate timestamp and Grafana links
-    oom_dt = datetime.now(ZoneInfo("Asia/Jerusalem"))
+    # Use alert timestamp if provided, else fall back to current time
+    tz_israel = ZoneInfo("Asia/Jerusalem")
+    if args.alert_timestamp:
+        try:
+            oom_dt = datetime.fromisoformat(args.alert_timestamp).astimezone(tz_israel)
+        except (ValueError, TypeError):
+            oom_dt = datetime.now(tz_israel)
+    else:
+        oom_dt = datetime.now(tz_israel)
     timestamp = oom_dt.strftime("%Y-%m-%d %H:%M:%S")
     oom_ts_ms = int(oom_dt.timestamp() * 1000)
     from_ms = oom_ts_ms - 10 * 60 * 1000
@@ -493,10 +515,12 @@ def main():
     try:
         report = asyncio.run(run_triage(args))
         if report:
+            # Scrub PII and sensitive URLs before any output
+            scrubbed_report = _scrub_report(report)
             print(f"\n{'='*60}")
             print("AI OOM Triage Report:")
             print(f"{'='*60}")
-            print(report)
+            print(scrubbed_report)
             print(f"{'='*60}")
 
             # Send to Google Chat

--- a/scripts/oom_handler.py
+++ b/scripts/oom_handler.py
@@ -451,7 +451,7 @@ def main(args):
                 ("cluster", args.cluster),
                 ("container", args.container),
                 ("customer_name", customer.name),
-                ("customer_email", customer.email),
+                ("customer_email", mask_email(customer.email)),
                 ("subscription_id", customer.subscription_id),
             ]:
                 f.write(f"{key}<<{delimiter}\n{val}\n{delimiter}\n")

--- a/scripts/oom_triage_tools.py
+++ b/scripts/oom_triage_tools.py
@@ -8,6 +8,7 @@ uses when investigating a ContainerOOMKilled event:
   - RDB/AOF dumps and local FalkorDB instance for database inspection
 """
 
+import math
 import os
 import re
 import json
@@ -15,6 +16,7 @@ import shlex
 import subprocess
 import tarfile
 import tempfile
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -45,7 +47,14 @@ def _download_gcs_or_url(url: str, dest: str) -> Optional[str]:
     """Download a file from a gs:// path (using ADC) or HTTPS URL.
 
     Returns an error string on failure, or None on success.
+    Only allows gs:// paths or HTTPS URLs from known GCS signed-URL hosts.
     """
+    # Allowed HTTPS hosts for signed download URLs
+    _ALLOWED_HTTPS_HOSTS = {
+        "storage.googleapis.com",
+        "storage.cloud.google.com",
+    }
+
     try:
         if url.startswith("gs://"):
             without_scheme = url[len("gs://"):]
@@ -53,12 +62,18 @@ def _download_gcs_or_url(url: str, dest: str) -> Optional[str]:
             client = gcs_storage.Client()
             bucket = client.bucket(bucket_name)
             bucket.blob(blob_name).download_to_filename(dest)
-        else:
+        elif url.startswith("https://"):
+            from urllib.parse import urlparse
+            parsed = urlparse(url)
+            if parsed.hostname not in _ALLOWED_HTTPS_HOSTS:
+                return f"ERROR: Host '{parsed.hostname}' is not in the allowed download hosts whitelist."
             with requests.get(url, timeout=300, stream=True) as resp:
                 resp.raise_for_status()
                 with open(dest, "wb") as f:
                     for chunk in resp.iter_content(chunk_size=8 * 1024 * 1024):
                         f.write(chunk)
+        else:
+            return f"ERROR: Unsupported URL scheme. Only gs:// and https:// from allowed hosts are supported."
     except Exception as exc:
         return f"ERROR: Failed to download {url}: {exc}"
     return None
@@ -193,7 +208,9 @@ async def query_metrics(params: QueryMetricsParams) -> str:
         numeric_values = []
         for ts, val in values:
             try:
-                numeric_values.append(float(val))
+                v = float(val)
+                if math.isfinite(v):
+                    numeric_values.append(v)
             except (ValueError, TypeError):
                 pass
 
@@ -307,6 +324,9 @@ async def fetch_logs(params: FetchLogsParams) -> str:
 
     full_log = "\n".join(cleaned)
 
+    # Scrub emails from logs to avoid PII leaking into AI context / Actions logs
+    full_log = _EMAIL_RE.sub(lambda m: m.group(0)[0] + "****@" + m.group(0).split("@")[1], full_log)
+
     # Cap output to prevent overwhelming LLM context
     MAX_LOG_BYTES = 100_000
     if len(full_log) > MAX_LOG_BYTES:
@@ -340,6 +360,10 @@ async def run_falkordb_local(params: RunFalkorDBLocalParams) -> str:
 
     if _local_container_id:
         subprocess.run(["docker", "rm", "-f", _local_container_id], capture_output=True)
+        _local_container_id = None
+
+    # Remove any leftover container with the same name to avoid conflicts
+    subprocess.run(["docker", "rm", "-f", "falkordb-oom-triage"], capture_output=True)
 
     _work_dir = tempfile.mkdtemp(prefix="falkordb_oom_triage_")
     data_dir = os.path.join(_work_dir, "data")
@@ -376,8 +400,30 @@ async def run_falkordb_local(params: RunFalkorDBLocalParams) -> str:
         return f"ERROR: Docker run failed: {result.stderr}"
 
     _local_container_id = result.stdout.strip()
+
+    # Wait for Redis to be ready (bounded readiness loop)
+    ready = False
+    for _ in range(30):
+        ping = subprocess.run(
+            ["redis-cli", "-p", "6399", "PING"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if ping.returncode == 0 and "PONG" in ping.stdout:
+            ready = True
+            break
+        time.sleep(1)
+
+    if not ready:
+        return (
+            f"WARNING: Container started but Redis not ready after 30s.\n"
+            f"Container: {_local_container_id[:12]}\n"
+            f"Image: {image}\n"
+            f"Port: 6399\n"
+            f"The container may still be loading a large RDB/AOF. Retry execute_query shortly."
+        )
+
     return (
-        f"FalkorDB container started.\n"
+        f"FalkorDB container started and ready.\n"
         f"Container: {_local_container_id[:12]}\n"
         f"Image: {image}\n"
         f"Port: 6399\n"


### PR DESCRIPTION
…ipeline

- Add bounded readiness loop (redis-cli PING) after docker run in run_falkordb_local
- Remove stale container by name before starting to avoid name conflicts
- Whitelist allowed HTTPS hosts in _download_gcs_or_url (only GCS signed-URL domains)
- Mask customer email in GITHUB_OUTPUT (oom_handler.py)
- Support --alert-timestamp CLI arg for Grafana link accuracy (fallback: now)
- Centralize report scrubbing (_scrub_report) for emails + signed URLs
- Scrub stdout printing of report before Actions logs
- HTML-escape all AI-provided fields in Google Chat card (not just recommended_action)
- Use args.container in initial prompt instead of hardcoded 'service'
- Move actor authorization to prerequisite job (blocks upload-rdb + ai-oom-triage)
- Scrub emails in fetch_logs tool output
- Filter NaN/inf values in query_metrics summary stats